### PR TITLE
feat: add integration tests, add huggingface client, fix anthropic client 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.10"
 dependencies = [
     "google-genai>=1.2.0",
     "google-generativeai>=0.8.5",
+    "huggingface-hub>=0.33.4",
     "instructor>=1.7.9",
     "isort>=6.0.1",
     "jsonref>=1.1.0",

--- a/src/knowornot/SyncLLMClient/anthropic_client.py
+++ b/src/knowornot/SyncLLMClient/anthropic_client.py
@@ -35,18 +35,14 @@ class SyncAnthropicClient(SyncLLMClient):
             messages.append({"role": "user", "content": prompt})
         else:
             for m in prompt:
-                if m.role == "system":
-                    system_prompt = m.content
-                else:
-                    messages.append({"role": m.role, "content": m.content})
-        return messages, system_prompt
+                messages.append({"role": m.role, "content": m.content})
+        return messages
 
     def _prompt(self, prompt: Union[str, List[Message]], ai_model: str) -> str:
-        messages, system_prompt = self._convert_messages(prompt)
+        messages = self._convert_messages(prompt)
         response = self.client.messages.create(
             model=ai_model,
             messages=messages,
-            system=system_prompt,
             max_tokens=1024,
         )
         output = response.content[0].text if response.content else None
@@ -62,11 +58,10 @@ class SyncAnthropicClient(SyncLLMClient):
         response_model: Type[T],
         model_used: str,
     ) -> T:
-        messages, system_prompt = self._convert_messages(prompt)
+        messages = self._convert_messages(prompt)
         response = self.instructor_client.messages.create(
             model=model_used,
             messages=messages,
-            system=system_prompt,
             response_model=response_model,
             max_tokens=1024,
         )

--- a/src/knowornot/SyncLLMClient/anthropic_client.py
+++ b/src/knowornot/SyncLLMClient/anthropic_client.py
@@ -29,8 +29,16 @@ class SyncAnthropicClient(SyncLLMClient):
         )
 
     def _convert_messages(self, prompt: Union[str, List[Message]]):
+        """
+        Converts the input prompt into a list of messages in a format suitable for the Anthropic API.
+
+        Args:
+            prompt: The input prompt to convert. It can be a string or a list of `Message` objects.
+
+        Returns:
+            A list of messages in the format required by the Anthropic API.
+        """
         messages = []
-        system_prompt: Optional[str] = None
         if isinstance(prompt, str):
             messages.append({"role": "user", "content": prompt})
         else:

--- a/src/knowornot/SyncLLMClient/azure_client.py
+++ b/src/knowornot/SyncLLMClient/azure_client.py
@@ -2,16 +2,6 @@ from typing import List, Optional, Type, TypeVar, Union
 
 import instructor
 from openai import AzureOpenAI
-from openai.types.chat import ChatCompletionMessageParam
-from openai.types.chat.chat_completion_assistant_message_param import (
-    ChatCompletionAssistantMessageParam,
-)
-from openai.types.chat.chat_completion_system_message_param import (
-    ChatCompletionSystemMessageParam,
-)
-from openai.types.chat.chat_completion_user_message_param import (
-    ChatCompletionUserMessageParam,
-)
 from pydantic import BaseModel
 import warnings
 
@@ -70,35 +60,7 @@ class SyncAzureOpenAIClient(SyncLLMClient):
         Raises:
             ValueError: If the response from the model does not contain any content.
         """
-        messages: List[ChatCompletionMessageParam] = []
-
-        if isinstance(prompt, str):
-            user_message: ChatCompletionUserMessageParam = {
-                "role": "user",
-                "content": prompt,
-            }
-            messages.append(user_message)
-        else:
-            for m in prompt:
-                if m.role == "user":
-                    user_message: ChatCompletionUserMessageParam = {
-                        "role": "user",
-                        "content": m.content,
-                    }
-                    messages.append(user_message)
-                elif m.role == "system":
-                    system_message: ChatCompletionSystemMessageParam = {
-                        "role": "system",
-                        "content": m.content,
-                    }
-                    messages.append(system_message)
-                elif m.role == "assistant":
-                    assistant_message: ChatCompletionAssistantMessageParam = {
-                        "role": "assistant",
-                        "content": m.content,
-                    }
-                    messages.append(assistant_message)
-                # Add others as needed
+        messages = self._convert_to_chat_messages(prompt)
 
         response = self.client.chat.completions.create(
             model=ai_model,
@@ -138,35 +100,7 @@ class SyncAzureOpenAIClient(SyncLLMClient):
         Raises:
             ValueError: If the response from the model does not contain any content.
         """
-        messages: List[ChatCompletionMessageParam] = []
-
-        if isinstance(prompt, str):
-            user_message: ChatCompletionUserMessageParam = {
-                "role": "user",
-                "content": prompt,
-            }
-            messages.append(user_message)
-        else:
-            for m in prompt:
-                if m.role == "user":
-                    user_message: ChatCompletionUserMessageParam = {
-                        "role": "user",
-                        "content": m.content,
-                    }
-                    messages.append(user_message)
-                elif m.role == "system":
-                    system_message: ChatCompletionSystemMessageParam = {
-                        "role": "system",
-                        "content": m.content,
-                    }
-                    messages.append(system_message)
-                elif m.role == "assistant":
-                    assistant_message: ChatCompletionAssistantMessageParam = {
-                        "role": "assistant",
-                        "content": m.content,
-                    }
-                    messages.append(assistant_message)
-                # Add others as needed
+        messages = self._convert_to_chat_messages(prompt)
 
         response = self.instructor_client.chat.completions.create(
             model=model_used,

--- a/src/knowornot/SyncLLMClient/bedrock_client.py
+++ b/src/knowornot/SyncLLMClient/bedrock_client.py
@@ -41,6 +41,18 @@ class SyncBedrockClient(SyncLLMClient):
         )
 
     def _convert_messages(self, prompt: Union[str, List[Message]]):
+        """
+        Converts the input prompt, which can be a string or a list of `Message` objects,
+        into a user prompt and an optional system prompt suitable for the Bedrock
+        converse API.
+
+        Args:
+            prompt: The input prompt(s) to send to the chat model. It can be a single string or a list of
+                    `Message` objects, where each message has a role (user, system, or assistant) and content.
+
+        Returns:
+            A tuple of the user prompt as a string and the system prompt as an optional string.
+        """
         user_prompt = ""
         system_prompt = None
         if isinstance(prompt, str):

--- a/src/knowornot/SyncLLMClient/gemini_client.py
+++ b/src/knowornot/SyncLLMClient/gemini_client.py
@@ -128,35 +128,7 @@ class SyncGeminiClient(SyncLLMClient):
                 "Gemini does not support a different model than the default model. Please instantiate a separate Gemini client for different models."
             )
 
-        messages: List[ChatCompletionMessageParam] = []
-
-        if isinstance(prompt, str):
-            user_message: ChatCompletionUserMessageParam = {
-                "role": "user",
-                "content": prompt,
-            }
-            messages.append(user_message)
-        else:
-            for m in prompt:
-                if m.role == "user":
-                    user_message: ChatCompletionUserMessageParam = {
-                        "role": "user",
-                        "content": m.content,
-                    }
-                    messages.append(user_message)
-                elif m.role == "system":
-                    system_message: ChatCompletionSystemMessageParam = {
-                        "role": "system",
-                        "content": m.content,
-                    }
-                    messages.append(system_message)
-                elif m.role == "assistant":
-                    assistant_message: ChatCompletionAssistantMessageParam = {
-                        "role": "assistant",
-                        "content": m.content,
-                    }
-                    messages.append(assistant_message)
-                # Add others as needed
+        messages = self._convert_to_chat_messages(prompt)
 
         # Use instructor to generate structured response
         response = self.instructor_client.chat.completions.create(

--- a/src/knowornot/SyncLLMClient/gemini_client.py
+++ b/src/knowornot/SyncLLMClient/gemini_client.py
@@ -10,16 +10,6 @@ from pydantic import BaseModel
 from ..config import GeminiConfig, ToolType
 from .exceptions import InitialCallFailedException
 from . import Message, SyncLLMClient, SyncLLMClientEnum
-from openai.types.chat import ChatCompletionMessageParam
-from openai.types.chat.chat_completion_assistant_message_param import (
-    ChatCompletionAssistantMessageParam,
-)
-from openai.types.chat.chat_completion_system_message_param import (
-    ChatCompletionSystemMessageParam,
-)
-from openai.types.chat.chat_completion_user_message_param import (
-    ChatCompletionUserMessageParam,
-)
 
 T = TypeVar("T", bound=BaseModel)
 

--- a/src/knowornot/SyncLLMClient/huggingface_client.py
+++ b/src/knowornot/SyncLLMClient/huggingface_client.py
@@ -1,0 +1,80 @@
+from typing import TypeVar, Union, List
+from huggingface_hub import InferenceClient
+from pydantic import BaseModel
+
+from ..config import HuggingFaceConfig
+from . import SyncLLMClient, Message, SyncLLMClientEnum
+
+T = TypeVar("T", bound=BaseModel)
+
+class SyncHuggingFaceClient(SyncLLMClient):
+    def __init__(self, config: HuggingFaceConfig):
+        self.config = config
+        self.logger = config.logger
+        self.client = InferenceClient(
+            provider=config.provider,
+            api_key=config.api_key,
+            bill_to=config.bill_to,
+        )
+
+    def _convert_messages(self, prompt: Union[str, List[Message]]):
+        """
+        Converts the input prompt into a list of messages in a format suitable for the Anthropic API.
+
+        Args:
+            prompt: The input prompt to convert. It can be a string or a list of `Message` objects.
+
+        Returns:
+            A list of messages in the format required by the Anthropic API.
+        """
+        messages = []
+        if isinstance(prompt, str):
+            messages.append({"role": "user", "content": prompt})
+        else:
+            for m in prompt:
+                messages.append({"role": m.role, "content": m.content})
+        return messages
+
+    def _generate_structured_response(self, prompt: Union[str, List[Message]], response_model: T, model_used: str) -> T:
+        # Define the response format
+        response_format = {
+            "type": "json_object",
+            "value": response_model.model_json_schema(),
+            "strict": True,
+        }
+ 
+        messages = self._convert_messages(prompt)
+
+        # Generate structured output using the specified model
+        response = self.client.chat_completion(
+            messages=messages,
+            response_format=response_format,
+            model=model_used,
+        )
+
+        # The response is guaranteed to match your schema
+        structured_data = response.choices[0].message.content
+
+        return response_model.parse_raw(structured_data)
+
+    def _prompt(self, prompt: Union[str, List[Message]], ai_model: str) -> str:
+
+        messages = self._convert_messages(prompt)
+
+        # Generate text using the specified model
+        response = self.client.chat_completion(
+            messages=messages,
+            model=ai_model,
+        )
+
+        # The response is a string
+        return response.choices[0].message.content
+
+
+    def get_embedding(self, prompt: str, model: str) -> list:
+        # Not implemented for Hugging Face
+        raise NotImplementedError
+    
+    @property
+    def enum_name(self) -> SyncLLMClientEnum:
+        return SyncLLMClientEnum.HUGGINGFACE

--- a/src/knowornot/SyncLLMClient/huggingface_client.py
+++ b/src/knowornot/SyncLLMClient/huggingface_client.py
@@ -50,7 +50,7 @@ class SyncHuggingFaceClient(SyncLLMClient):
         strict_messages = []
         for message in messages:
             if message["role"] == "user":
-                strict_messages.append({"role": message["role"], "content": message["content"] + "\nOnly use integer or exactly `no citation` — nothing else"})
+                strict_messages.append({"role": message["role"], "content": message["content"] + "\nOnly use integer or exactly `no citation` for citation — nothing else"})
             else:
                 strict_messages.append(message)
         return strict_messages
@@ -67,7 +67,8 @@ class SyncHuggingFaceClient(SyncLLMClient):
         }
  
         messages = self._convert_messages(prompt)
-        messages = self._add_strict_prompt(messages)
+        if response_model.__name__ == "QAResponse":
+            messages = self._add_strict_prompt(messages)
 
         response = self.client.chat_completion(
             messages=messages,

--- a/src/knowornot/SyncLLMClient/openai_client.py
+++ b/src/knowornot/SyncLLMClient/openai_client.py
@@ -1,16 +1,6 @@
 from typing import List, Optional, Type, TypeVar, Union
 import instructor
 from openai import OpenAI
-from openai.types.chat import ChatCompletionMessageParam
-from openai.types.chat.chat_completion_assistant_message_param import (
-    ChatCompletionAssistantMessageParam,
-)
-from openai.types.chat.chat_completion_system_message_param import (
-    ChatCompletionSystemMessageParam,
-)
-from openai.types.chat.chat_completion_user_message_param import (
-    ChatCompletionUserMessageParam,
-)
 from pydantic import BaseModel
 
 from ..config import OpenAIConfig, ToolType, Tool
@@ -66,49 +56,6 @@ class SyncOpenAIClient(SyncLLMClient):
             raise ValueError(
                 f"Model {model} is not supported for search queries for ßOpenAI."
             )
-
-    def _convert_to_chat_messages(
-        self, prompt: Union[str, List[Message]]
-    ) -> List[ChatCompletionMessageParam]:
-        """
-        Converts a prompt (either string or list of Message objects) into a list of ChatCompletionMessageParam.
-
-        Args:
-            prompt: Either a string or a list of Message objects
-
-        Returns:
-            List[ChatCompletionMessageParam]: List of messages in OpenAI chat format
-        """
-        messages: List[ChatCompletionMessageParam] = []
-
-        if isinstance(prompt, str):
-            user_message: ChatCompletionUserMessageParam = {
-                "role": "user",
-                "content": prompt,
-            }
-            messages.append(user_message)
-        else:
-            for m in prompt:
-                if m.role == "user":
-                    user_message: ChatCompletionUserMessageParam = {
-                        "role": "user",
-                        "content": m.content,
-                    }
-                    messages.append(user_message)
-                elif m.role == "system":
-                    system_message: ChatCompletionSystemMessageParam = {
-                        "role": "system",
-                        "content": m.content,
-                    }
-                    messages.append(system_message)
-                elif m.role == "assistant":
-                    assistant_message: ChatCompletionAssistantMessageParam = {
-                        "role": "assistant",
-                        "content": m.content,
-                    }
-                    messages.append(assistant_message)
-
-        return messages
 
     def _prompt(self, prompt: Union[str, List[Message]], ai_model: str) -> str:
         """

--- a/src/knowornot/SyncLLMClient/openrouter_client.py
+++ b/src/knowornot/SyncLLMClient/openrouter_client.py
@@ -7,16 +7,6 @@ from ..config import OpenRouterConfig
 from ..SyncLLMClient import Message, SyncLLMClient, SyncLLMClientEnum
 from openai import OpenAI
 
-from openai.types.chat import ChatCompletionMessageParam
-from openai.types.chat.chat_completion_assistant_message_param import (
-    ChatCompletionAssistantMessageParam,
-)
-from openai.types.chat.chat_completion_system_message_param import (
-    ChatCompletionSystemMessageParam,
-)
-from openai.types.chat.chat_completion_user_message_param import (
-    ChatCompletionUserMessageParam,
-)
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -51,48 +41,6 @@ class SyncOpenRouterClient(SyncLLMClient):
         else:
             self.instructor_client = None
 
-    def _convert_to_chat_messages(
-        self, prompt: Union[str, List[Message]]
-    ) -> List[ChatCompletionMessageParam]:
-        """
-        Converts a prompt (either string or list of Message objects) into a list of ChatCompletionMessageParam.
-
-        Args:
-            prompt: Either a string or a list of Message objects
-
-        Returns:
-            List[ChatCompletionMessageParam]: List of messages in OpenAI chat format
-        """
-        messages: List[ChatCompletionMessageParam] = []
-
-        if isinstance(prompt, str):
-            user_message: ChatCompletionUserMessageParam = {
-                "role": "user",
-                "content": prompt,
-            }
-            messages.append(user_message)
-        else:
-            for m in prompt:
-                if m.role == "user":
-                    user_message: ChatCompletionUserMessageParam = {
-                        "role": "user",
-                        "content": m.content,
-                    }
-                    messages.append(user_message)
-                elif m.role == "system":
-                    system_message: ChatCompletionSystemMessageParam = {
-                        "role": "system",
-                        "content": m.content,
-                    }
-                    messages.append(system_message)
-                elif m.role == "assistant":
-                    assistant_message: ChatCompletionAssistantMessageParam = {
-                        "role": "assistant",
-                        "content": m.content,
-                    }
-                    messages.append(assistant_message)
-
-        return messages
 
     def _prompt(self, prompt: Union[str, List[Message]], ai_model: str) -> str:
         """

--- a/src/knowornot/config/__init__.py
+++ b/src/knowornot/config/__init__.py
@@ -82,6 +82,20 @@ class AzureOpenAIConfig(LLMClientConfig):
 
 
 @dataclass
+class HuggingFaceConfig(LLMClientConfig):
+    can_use_instructor: bool = True
+    default_embedding_model: str = ""
+    provider: str = ""
+    bill_to: Optional[str] = None
+
+    def __post_init__(self):
+        if not self.api_key:
+            raise ValueError("api_key is required for HuggingFaceConfig")
+        if not self.provider:
+            raise ValueError("provider is required for HuggingFaceConfig")
+
+
+@dataclass
 class OpenAIConfig(LLMClientConfig):
     can_use_instructor: bool = True
     can_use_tools: bool = True

--- a/tests/test_syncllmclient_integration.py
+++ b/tests/test_syncllmclient_integration.py
@@ -44,7 +44,7 @@ class TestSyncLLMClientIntegration(unittest.TestCase):
     def test_huggingface_client(self):
         kon = KnowOrNot()
         kon.add_huggingface()
-        self._test_client_string(kon.get_client(SyncLLMClientEnum.HUGGINGFACE))
+        self._test_client_structured(kon.get_client(SyncLLMClientEnum.HUGGINGFACE))
 
     def _test_client_structured(self, client):
         # Test sending a prompt and receiving a structured response

--- a/tests/test_syncllmclient_integration.py
+++ b/tests/test_syncllmclient_integration.py
@@ -1,6 +1,7 @@
 # tests/test_syncllmclient_integration.py
 
 import unittest
+import os
 from dotenv import load_dotenv
 
 from src.knowornot import KnowOrNot
@@ -39,6 +40,11 @@ class TestSyncLLMClientIntegration(unittest.TestCase):
         kon = KnowOrNot()
         kon.add_openrouter()
         self._test_client_string(kon.get_client(SyncLLMClientEnum.OPENROUTER))
+    
+    def test_huggingface_client(self):
+        kon = KnowOrNot()
+        kon.add_huggingface()
+        self._test_client_string(kon.get_client(SyncLLMClientEnum.HUGGINGFACE))
 
     def _test_client_structured(self, client):
         # Test sending a prompt and receiving a structured response

--- a/tests/test_syncllmclient_integration.py
+++ b/tests/test_syncllmclient_integration.py
@@ -1,0 +1,57 @@
+# tests/test_syncllmclient_integration.py
+
+import unittest
+from dotenv import load_dotenv
+
+from src.knowornot import KnowOrNot
+from src.knowornot.SyncLLMClient import SyncLLMClient, SyncLLMClientEnum
+from src.knowornot.common.models import QAResponse
+
+load_dotenv()
+
+class TestSyncLLMClientIntegration(unittest.TestCase):
+    def test_openai_client(self):
+        kon = KnowOrNot()
+        kon.add_openai()
+        self._test_client_structured(kon.get_client(SyncLLMClientEnum.OPENAI))
+
+    def test_azure_openai_client(self):
+        kon = KnowOrNot()
+        kon.add_azure()
+        self._test_client_structured(kon.get_client(SyncLLMClientEnum.AZURE_OPENAI))
+
+    def test_anthropic_client(self):
+        kon = KnowOrNot()
+        kon.add_anthropic()
+        self._test_client_structured(kon.get_client(SyncLLMClientEnum.ANTHROPIC))
+
+    def test_bedrock_client(self):
+        kon = KnowOrNot()
+        kon.add_bedrock()
+        self._test_client_structured(kon.get_client(SyncLLMClientEnum.BEDROCK))
+
+    def test_gemini_client(self):
+        kon = KnowOrNot()
+        kon.add_gemini()
+        self._test_client_string(kon.get_client(SyncLLMClientEnum.GEMINI))
+
+    def test_openrouter_client(self):
+        kon = KnowOrNot()
+        kon.add_openrouter()
+        self._test_client_string(kon.get_client(SyncLLMClientEnum.OPENROUTER))
+
+    def _test_client_structured(self, client):
+        # Test sending a prompt and receiving a structured response
+        prompt = "What is the capital of France?"
+        response_model = QAResponse
+
+        response = client.get_structured_response(prompt, response_model)
+        self.assertIsInstance(response, QAResponse)
+        self.assertIsNotNone(response.response)
+    
+    def _test_client_string(self, client):
+        # Test sending a prompt and receiving a text response
+        prompt = "What is the capital of France?"
+
+        response = client.prompt(prompt)
+        self.assertIsInstance(response, str)


### PR DESCRIPTION
## Changes

1. Add integration tests for all `SyncLLMClient` classes, except `Groq`
2. Add `SyncHuggingFaceClient`, with support for structured outputs
3. Fix bug in `SyncAnthropicClient`
4. Refactor `SyncLLMClient` class by adding common class method `_convert_to_chat_messages` 
5. Added docstrings where appropriate

---

## Testing

- Integration tests added under `tests/test_syncllmclient_integration.py`

---

## Notes / Future Work

- `SyncHuggingFaceClient` structured outputs may not be completely foolproof
-- `Instructor` does not support HuggingFace directly
-- `Instructor` supports the `OpenAI` SDK, which can be used with HuggingFace. But when the `X-HF-Bill-To` header is added, results in error `Only Inference Providers with accurate pricing are available for organizations.`, as documented in [here](https://discuss.huggingface.co/t/i-am-getting-this-error-only-inference-providers-with-accurate-pricing-are-available-for-organizations/163607). Likely a huggingface regression issue and did not manage to trace this error message in huggingface-hub and openai's SDK Github
-- `response_format` in huggingface-hub's `InferenceClient` class is meant to enforce the Pydantic model and [get structured outputs](https://huggingface.co/docs/inference-providers/en/guides/structured-output) but empirical experiment shows otherwise. Provided `QAResponse` model which specifies `int` or `Literal['no citation']` but received `common_understanding` as value instead.
-- Added a stricter prompt to user messages to ensure compliance if `response_model == QAResponse` 
- `Groq` SyncLLMClient not yet tested