### PR TITLE
Improve structured responses for sync LLM clients

### DIFF
--- a/src/knowornot/ExperimentManager/__init__.py
+++ b/src/knowornot/ExperimentManager/__init__.py
@@ -240,7 +240,7 @@ class ExperimentManager:
 
         llm_response_list: List[SavedLLMResponse] = []
         for idx, experiment_input in enumerate(experiment.questions):
-            self.logger.info(f"Running question {idx}")
+            # self.logger.info(f"Running question {idx}")
             answer = sync_client.get_structured_response(
                 prompt=experiment_input.prompt_to_llm,
                 ai_model=experiment.metadata.ai_model_used,
@@ -255,7 +255,7 @@ class ExperimentManager:
             )
 
             llm_response_list.append(final_response)
-            self.logger.info(f"Finished question {idx}")
+            # self.logger.info(f"Finished question {idx}")
 
         return ExperimentOutputDocument(
             metadata=experiment.metadata, responses=llm_response_list
@@ -265,7 +265,7 @@ class ExperimentManager:
         self,
         experiment: ExperimentInputDocument,
         client_registry: Dict[SyncLLMClientEnum, SyncLLMClient],
-        max_workers: int = 8,
+        max_workers: int = 1,
     ) -> ExperimentOutputDocument:
         """Run an experiment asynchronously."""
         client_enum = experiment.metadata.client_enum
@@ -288,7 +288,7 @@ class ExperimentManager:
         )
 
         async def process_question(idx: int, experiment_input):
-            self.logger.info(f"Starting question {idx}")
+            # self.logger.info(f"Starting question {idx}")
 
             # Run the synchronous API call in a thread
             answer = await loop.run_in_executor(
@@ -307,7 +307,7 @@ class ExperimentManager:
                 idx=idx,
             )
 
-            self.logger.info(f"Finished question {idx}")
+            # self.logger.info(f"Finished question {idx}")
             return idx, final_response
 
         # Create tasks for all questions
@@ -343,7 +343,7 @@ class ExperimentManager:
         self,
         experiments: List[ExperimentInputDocument],
         client_registry: Dict[SyncLLMClientEnum, SyncLLMClient],
-        max_workers: int = 8,
+        max_workers: int = 1,
     ) -> List[ExperimentOutputDocument]:
         """Run multiple experiments asynchronously."""
         self.logger.info(

--- a/src/knowornot/SyncLLMClient/bedrock_client.py
+++ b/src/knowornot/SyncLLMClient/bedrock_client.py
@@ -1,4 +1,5 @@
 from typing import List, Optional, Type, TypeVar, Union
+import instructor
 import instructor.client_bedrock as instructor_bedrock
 import boto3
 from pydantic import BaseModel
@@ -28,7 +29,7 @@ class SyncBedrockClient(SyncLLMClient):
             region_name=config.region_name,
         )
         self.logger = config.logger
-        self.instructor_client = instructor_bedrock.from_bedrock(self.client)
+        self.instructor_client = instructor_bedrock.from_bedrock(self.client, mode=instructor.Mode.BEDROCK_JSON)
 
         try:
             self.prompt("hello", ai_model=self.config.default_model)
@@ -78,12 +79,22 @@ class SyncBedrockClient(SyncLLMClient):
         model_used: str,
     ) -> T:
         user_prompt, system_prompt = self._convert_messages(prompt)
-        response = self.instructor_client.create(
-            modelId=model_used,
-            messages=[{"role": "user", "content": [{"text": user_prompt}]}],
-            system=[{"text": system_prompt}] if system_prompt else None,
-            response_model=response_model,
-        )
+        if system_prompt:
+            response = self.instructor_client.create(
+                modelId=model_used,
+                messages=[{"role": "user", "content": [{"text": user_prompt}]}],
+                system=[{"text": system_prompt}] if system_prompt else None,
+                response_model=response_model,
+            )
+        else:
+            response = self.instructor_client.create(
+                modelId=model_used,
+                messages=[{"role": "user", "content": [{"text": user_prompt}]}],
+                response_model=response_model,
+            )
+        if "</think>" in response.response:
+            response.response = response.response.split("</think>")[1]
+            return response_model.model_validate_json(response.response)
         return response
 
     def get_embedding(

--- a/src/knowornot/SyncLLMClient/huggingface_client.py
+++ b/src/knowornot/SyncLLMClient/huggingface_client.py
@@ -1,20 +1,40 @@
-from typing import TypeVar, Union, List, Dict
-from huggingface_hub import InferenceClient
+from typing import TypeVar, Union, List, Dict, Optional, Type
+import instructor
 from pydantic import BaseModel
+from huggingface_hub import InferenceClient
+
+from openai import OpenAI
 
 from ..config import HuggingFaceConfig
+from .exceptions import InitialCallFailedException
 from . import SyncLLMClient, Message, SyncLLMClientEnum
 
 T = TypeVar("T", bound=BaseModel)
 
 class SyncHuggingFaceClient(SyncLLMClient):
     def __init__(self, config: HuggingFaceConfig):
+        super().__init__(config)
         self.config = config
         self.logger = config.logger
-        self.client = InferenceClient(
-            provider=config.provider,
+        self.client = OpenAI(
+            base_url="https://router.huggingface.co/v1",
             api_key=config.api_key,
-            bill_to=config.bill_to,
+            default_headers={
+                "X-HF-Bill-To": config.bill_to
+            }
+        )
+        self.instructor_client = instructor.from_openai(
+            self.client, mode=instructor.Mode.TOOLS
+        )
+
+        try:
+            self.prompt("hello", ai_model=self.config.default_model)
+        except Exception as e:
+            raise InitialCallFailedException(
+                model_name=self.config.default_model, error_message=str(e)
+            )
+        self.logger.info(
+            f"Using model: {self.config.default_model} as the default model"
         )
 
     def _convert_messages(self, prompt: Union[str, List[Message]]):
@@ -50,60 +70,56 @@ class SyncHuggingFaceClient(SyncLLMClient):
         strict_messages = []
         for message in messages:
             if message["role"] == "user":
-                strict_messages.append({"role": message["role"], "content": message["content"] + "\nOnly use integer or exactly `no citation` for citation — nothing else"})
+                strict_messages.append({"role": message["role"], "content": message["content"] + "\nFor citation: return ONLY an integer (e.g., 1, 2, 3, etc.) or the exact string 'no citation'. Do not return anything else."})
             else:
                 strict_messages.append(message)
         return strict_messages
 
-    def _generate_structured_response(self, prompt: Union[str, List[Message]], response_model: T, model_used: str) -> T:
-        # Define the response format
-        response_format = {
-            "type": "json_schema",
-            "json_schema": {
-                "name": response_model.__name__,
-                "schema": {
-                    **response_model.model_json_schema(),
-                    "additionalProperties": False
-                },
-                "strict": True,
-            }
-        }
- 
+    def _prompt(self, prompt: Union[str, List[Message]], ai_model: str) -> str:
+        messages = self._convert_messages(prompt)
+
+        response = self.client.chat.completions.create(
+            messages=messages,
+            model=ai_model,
+        )
+        output = response.choices[0].message.content
+        if not output:
+            raise ValueError(
+                f"Expected output that was not none for {prompt} but got {output}"
+            )
+
+        return output
+
+    def _generate_structured_response(
+        self,
+        prompt: Union[str, List[Message]],
+        response_model: Type[T],
+        model_used: str,
+    ) -> T:
         messages = self._convert_messages(prompt)
         if response_model.__name__ == "QAResponse":
             messages = self._add_strict_prompt(messages)
 
-        response = self.client.chat_completion(
-            messages=messages,
-            response_format=response_format,
+        messages.append({"role": "user", "content": f"YOU MUST RETURN A JSON OBJECT WITH THE FOLLOWING SCHEMA: {response_model.model_json_schema()}"})
+
+        response = self.instructor_client.chat.completions.create(
             model=model_used,
-            max_tokens=10_000,
-        )
-        content = response.choices[0].message.content
-        if "</think>" in content:
-            content = content.split("</think>")[1]
-        structured_data = response_model.model_validate_json(content)
-
-        return structured_data
-        
-    def _prompt(self, prompt: Union[str, List[Message]], ai_model: str) -> str:
-
-        messages = self._convert_messages(prompt)
-
-        # Generate text using the specified model
-        response = self.client.chat_completion(
+            response_model=response_model,
             messages=messages,
-            model=ai_model,
         )
 
-        # The response is a string
-        return response.choices[0].message.content
+        content = response.choices[0].message.content
+        if "<think>" in content:
+            content = content.split("<think>")[1]
+            return response_model.model_validate_json(content)
 
+        return response
 
-    def get_embedding(self, prompt: str, model: str) -> list:
-        # Not implemented for Hugging Face
-        raise NotImplementedError
-    
+    def get_embedding(
+        self, prompt_list: List[str], model: Optional[str] = None
+    ) -> List[List[float]]:
+        raise NotImplementedError("HuggingFace does not support embeddings")
+
     @property
     def enum_name(self) -> SyncLLMClientEnum:
         return SyncLLMClientEnum.HUGGINGFACE

--- a/src/knowornot/SyncLLMClient/openai_client.py
+++ b/src/knowornot/SyncLLMClient/openai_client.py
@@ -124,6 +124,7 @@ class SyncOpenAIClient(SyncLLMClient):
                 model=model_used,
                 response_model=response_model,
                 messages=messages,
+                parallel_tool_calls=False,
             )
         except Exception as e:
             # Extract the error message directly from the exception
@@ -142,6 +143,7 @@ class SyncOpenAIClient(SyncLLMClient):
                 response_openai = self.client.chat.completions.create(
                     model=model_used,
                     messages=self._convert_to_chat_messages(json_template_messages),
+                    parallel_tool_calls=False,
                 )
 
                 if response_openai.choices[0].message.content:
@@ -158,6 +160,7 @@ class SyncOpenAIClient(SyncLLMClient):
                             model="gpt-4o-mini-2024-07-18",
                             response_model=response_model,
                             messages=self._convert_to_chat_messages([rewrite_messages]),
+                            parallel_tool_calls=False,
                         )
                     except Exception as e:
                         raise RuntimeError(


### PR DESCRIPTION
- `src/knowornot/ExperimentManager/__init__.py:241-347` – quieted per-question logging and forced async runners to operate with a single worker (and identical limit for multi-experiment
orchestration) to reduce noise and avoid out-of-order race conditions during structured-response collection.
- `src/knowornot/SyncLLMClient/huggingface_client.py:1-125` – rebuilt the Hugging Face client on top of the OpenAI router endpoint with Instructor/TOOL mode, added strict citation
instructions and schema enforcement for QAResponse, validated the default model on init, and documented that the client no longer exposes embeddings because the upstream route doesn’t
support them.
- `src/knowornot/SyncLLMClient/bedrock_client.py:1-105` – routed the Bedrock Instructor client through JSON mode, split structured-response creation to handle optional system prompts, and
strip any embedded </think> prefix before parsing the validated model output so downstream code always sees clean JSON.
- `src/knowornot/SyncLLMClient/openai_client.py:119-181` – disabled parallel_tool_calls on every chat completion (structured-path + fallback path + post-rewrite call) to keep Instructor-
driven structured responses deterministic even when tools aren’t involved.