### PR TITLE
feat: add configurable Instructor mode to OpenAI-compatible client

### DIFF
--- a/src/knowornot/SyncLLMClient/openai_client.py
+++ b/src/knowornot/SyncLLMClient/openai_client.py
@@ -12,7 +12,12 @@ T = TypeVar("T", bound=BaseModel)
 
 
 class SyncOpenAIClient(SyncLLMClient):
-    def __init__(self, config: OpenAIConfig, base_url: Optional[str] = None):
+    def __init__(
+        self,
+        config: OpenAIConfig,
+        base_url: Optional[str] = None,
+        instructor_mode: instructor.Mode = instructor.Mode.TOOLS_STRICT,
+    ):
         super().__init__(config)
 
         self.config = config
@@ -22,7 +27,7 @@ class SyncOpenAIClient(SyncLLMClient):
             self.client = OpenAI(api_key=config.api_key)
         self.logger = config.logger
         self.instructor_client = instructor.from_openai(
-            self.client, mode=instructor.Mode.TOOLS_STRICT
+            self.client, mode=instructor_mode
         )
 
         # Check if the tools are compatible with the model

--- a/src/knowornot/__init__.py
+++ b/src/knowornot/__init__.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from typing import Callable, Dict, List, Literal, Optional, Sequence, Union, Any
 import logging
 
+import instructor
+
 from .SyncLLMClient.openrouter_client import SyncOpenRouterClient
 from .SyncLLMClient.openai_client import SyncOpenAIClient
 from .SyncLLMClient.groq_client import SyncGroqClient
@@ -367,6 +369,7 @@ class KnowOrNot:
         organization: Optional[str] = None,
         tools: Optional[List[Dict[str, Any]]] = None,
         base_url: Optional[str] = None,
+        instructor_mode: instructor.Mode = instructor.Mode.TOOLS_STRICT,
     ) -> None:
         """
         Registers an OpenAI API client with the KnowOrNot instance.
@@ -383,6 +386,7 @@ class KnowOrNot:
             organization (str, optional): The organization to associate with the client. Defaults to ``None``.
             tools (List[Dict[str, Any]], optional): List of tool configurations. Each dict should have a 'type' key with a value of 'search'. Defaults to ``None``.
             base_url (str, optional): The base URL to use for the client. Defaults to ``None``.
+            instructor_mode (instructor.Mode, optional): The Instructor mode used for structured output. Defaults to ``instructor.Mode.TOOLS_STRICT`` to preserve native OpenAI strict-output behavior. Set to ``instructor.Mode.TOOLS`` for OpenAI-compatible endpoints (e.g. Bedrock Claude via PlatformAI) that reject the ``strict`` tool property.
 
         Raises:
             EnvironmentError: If ``api_key``, ``default_model``, or ``default_embedding_model`` are not provided and not found in the environment.
@@ -423,7 +427,9 @@ class KnowOrNot:
             tools=tool_objects,
         )
 
-        openai_sync_client = SyncOpenAIClient(config=config, base_url=base_url)
+        openai_sync_client = SyncOpenAIClient(
+            config=config, base_url=base_url, instructor_mode=instructor_mode
+        )
 
         self.register_client(client=openai_sync_client, make_default=True)
 

--- a/tests/test_openai_instructor_mode.py
+++ b/tests/test_openai_instructor_mode.py
@@ -1,0 +1,100 @@
+"""Tests for the configurable Instructor mode on the OpenAI-compatible client.
+
+PlatformAI exposes Bedrock Claude through an OpenAI-compatible endpoint.
+Instructor's TOOLS_STRICT mode adds ``strict: true`` to the tool definition,
+which Bedrock Claude rejects. These tests pin down the ability to select a
+different Instructor mode (e.g. TOOLS) while preserving the strict default for
+native OpenAI users.
+"""
+
+from typing import cast
+from unittest.mock import patch
+
+import instructor
+from pydantic import BaseModel
+
+from src.knowornot import KnowOrNot
+from src.knowornot.SyncLLMClient.openai_client import SyncOpenAIClient
+
+
+class WeatherResponse(BaseModel):
+    temperature: float
+    condition: str
+
+
+@patch("src.knowornot.SyncLLMClient.SyncLLMClient.prompt")
+def test_add_openai_defaults_to_tools_strict(mock_prompt):
+    """add_openai() must keep the strict-output default for native OpenAI users."""
+    mock_prompt.return_value = "Hello"
+    kon = KnowOrNot()
+    kon.add_openai(
+        api_key="sk-test",
+        default_model="gpt-4o",
+        default_embedding_model="text-embedding-3-small",
+    )
+
+    client = cast(SyncOpenAIClient, kon.default_sync_client)
+    assert client.instructor_client.mode == instructor.Mode.TOOLS_STRICT
+
+
+@patch("src.knowornot.SyncLLMClient.openai_client.instructor.from_openai")
+@patch("src.knowornot.SyncLLMClient.SyncLLMClient.prompt")
+def test_add_openai_forwards_custom_mode_to_from_openai(mock_prompt, mock_from_openai):
+    """Passing instructor.Mode.TOOLS must reach instructor.from_openai()."""
+    mock_prompt.return_value = "Hello"
+    kon = KnowOrNot()
+    kon.add_openai(
+        api_key="sk-test",
+        default_model="gpt-4o",
+        default_embedding_model="text-embedding-3-small",
+        instructor_mode=instructor.Mode.TOOLS,
+    )
+
+    assert mock_from_openai.call_args.kwargs["mode"] == instructor.Mode.TOOLS
+
+
+@patch("src.knowornot.SyncLLMClient.SyncLLMClient.prompt")
+def test_custom_mode_works_with_custom_base_url(mock_prompt):
+    """The custom mode must be honoured when a custom base_url is used (PlatformAI)."""
+    mock_prompt.return_value = "Hello"
+    kon = KnowOrNot()
+    kon.add_openai(
+        api_key="platform-key",
+        base_url="https://platform.example.com/v1",
+        default_model="bedrock.claude-opus-4-7",
+        default_embedding_model="text-embedding-3-small",
+        instructor_mode=instructor.Mode.TOOLS,
+    )
+
+    client = cast(SyncOpenAIClient, kon.default_sync_client)
+    assert client.instructor_client.mode == instructor.Mode.TOOLS
+    assert str(client.client.base_url) == "https://platform.example.com/v1/"
+
+
+@patch("src.knowornot.SyncLLMClient.SyncLLMClient.prompt")
+def test_non_strict_mode_does_not_emit_strict_in_tool_schema(mock_prompt):
+    """Regression: non-strict mode must not add `strict` to the tool definition.
+
+    Bedrock Claude rejects `tools.0.custom.strict: Extra inputs are not permitted`,
+    so the tool schema generated under the selected mode must omit `strict`.
+    """
+    from instructor.process_response import handle_response_model
+
+    mock_prompt.return_value = "Hello"
+    kon = KnowOrNot()
+    kon.add_openai(
+        api_key="platform-key",
+        base_url="https://platform.example.com/v1",
+        default_model="bedrock.claude-opus-4-7",
+        default_embedding_model="text-embedding-3-small",
+        instructor_mode=instructor.Mode.TOOLS,
+    )
+
+    client = cast(SyncOpenAIClient, kon.default_sync_client)
+    _, kwargs = handle_response_model(
+        response_model=WeatherResponse,
+        mode=client.instructor_client.mode,
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    tool_function = kwargs["tools"][0]["function"]
+    assert "strict" not in tool_function


### PR DESCRIPTION
SyncOpenAIClient hardcoded instructor.Mode.TOOLS_STRICT, which adds `strict: true` to the tool definition. OpenAI-compatible endpoints such as Bedrock Claude via PlatformAI reject this with
`tools.0.custom.strict: Extra inputs are not permitted`.

Add an `instructor_mode` argument to SyncOpenAIClient.__init__ and KnowOrNot.add_openai(), defaulting to TOOLS_STRICT so native OpenAI users retain strict-output behavior. Callers targeting Bedrock Claude can pass instructor.Mode.TOOLS to omit the `strict` property.

Tests cover the TOOLS_STRICT default, forwarding a custom mode to instructor.from_openai, custom mode with a custom base_url, and a regression ensuring non-strict mode emits no `strict` in the tool schema.